### PR TITLE
fix: fix the out of bounds issue I ran into

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ pub use backtrace_support::{BacktraceMetric, BacktraceReport, HashedBacktrace};
 /// next thread id incrementor
 static THREAD_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-const MAX_THREADS: usize = 256;
+/// On linux you can check your system by running `cat /proc/sys/kernel/threads-max`
+/// It's almost certain that this limit will be hit in some strange corner cases.
+const MAX_THREADS: usize = 1024;
 
 #[derive(Clone, Copy, Debug)]
 struct PointerData {
@@ -127,6 +129,10 @@ unsafe impl<T: GlobalAlloc> GlobalAlloc for AllocTrack<T> {
             let size = layout.size();
             let ptr = self.inner.alloc(layout);
             let tid = THREAD_ID.with(|x| *x);
+            assert!(
+                tid < MAX_THREADS,
+                "Thread ID {tid} is greater than the maximum number of threads {MAX_THREADS}"
+            );
             #[cfg(feature = "fs")]
             if THREAD_STORE[tid].tid.load(Ordering::Relaxed) == 0 {
                 let os_tid = get_sys_tid();
@@ -401,7 +407,6 @@ pub fn thread_report() -> ThreadReport {
     ThreadReport(metrics)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,5 +423,4 @@ mod tests {
         let os_tid_names = os_tid_names();
         println!("{:?}", os_tid_names);
     }
-
 }


### PR DESCRIPTION
- the max threads limit was reached in my application case and the access into the `THREAD_STORE` failed with an out of bounds access
- so I increase the threads max by 4x
- and introduce an explicit assert with a more clear message in order to avoid confusion of whats the actual problem